### PR TITLE
Modified the FileUpload component in Vue to upload the selected file to WebAPI

### DIFF
--- a/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Controllers/FilesController.cs
+++ b/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Controllers/FilesController.cs
@@ -21,9 +21,9 @@ namespace landscape_architecture.WebAPI.Controllers
 
         [HttpPost]
         [Route("UploadFile")]
-        public async Task<ActionResult> UploadFile(IFormFile file)
+        public async Task<ActionResult> UploadFile([FromForm] FileUploadDTO fileDto)
         {
-            var result = await _filesService.UploadFile(file);
+            var result = await _filesService.UploadFile(fileDto);
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);

--- a/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Controllers/FilesController.cs
+++ b/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Controllers/FilesController.cs
@@ -24,11 +24,11 @@ namespace landscape_architecture.WebAPI.Controllers
         public async Task<ActionResult> UploadFile(IFormFile file)
         {
             var result = await _filesService.UploadFile(file);
-            if (result == "")
+            if (!ModelState.IsValid)
             {
-                // TODO: Add more specific exception handling
-                return BadRequest("Invalid file upload");
+                return BadRequest(ModelState);
             }
+
             return Ok("Successfully uploaded file " + result);
         }
 

--- a/landscape-architecture.WebAPI/landscape-architecture.WebAPI/DTO/FileUploadDTO.cs
+++ b/landscape-architecture.WebAPI/landscape-architecture.WebAPI/DTO/FileUploadDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace landscape_architecture.WebAPI.DTO
+{
+    public class FileUploadDTO
+    {
+        public string FileName { get; set; }
+        public IFormFile FormFile { get; set; }
+    }
+}

--- a/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Program.cs
+++ b/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Program.cs
@@ -48,6 +48,8 @@ app.UseForwardedHeaders(new ForwardedHeadersOptions
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
 });
 
+app.UseCors();
+
 app.UseHttpsRedirection();
 
 app.UseAuthorization();

--- a/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Services/FilesService.cs
+++ b/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Services/FilesService.cs
@@ -24,16 +24,19 @@ namespace landscape_architecture.WebAPI.Services
          * This file will be stored in the database as a byte array, with a generated GUID as the file name and the file extension.
          * Then we want to return the GUID to the controller as validation that the file was uploaded successfully.
          */
-        public async Task<string> UploadFile(IFormFile formFile)
+        public async Task<string> UploadFile(FileUploadDTO fileDto)
         {
             string fileName = "";
             try
             {
-                FileInfo fileInfo = new FileInfo(formFile.FileName);
-                fileName = formFile.FileName + "_" + Guid.NewGuid().ToString() + fileInfo.Extension;
+                FileInfo fileInfo = new FileInfo(fileDto.FormFile.FileName);
+                string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileDto.FileName);
+                // Milliseconds since epoch, to ensure unique file names
+                long milliseconds = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+                fileName = fileNameWithoutExtension + "_" + milliseconds + fileInfo.Extension; 
                 using (MemoryStream stream = new MemoryStream())
                 {
-                    await formFile.CopyToAsync(stream);
+                    await fileDto.FormFile.CopyToAsync(stream);
                     UploadedFile uploadedFile = new UploadedFile()
                     {
                         FileName = fileName,

--- a/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Services/IFilesService.cs
+++ b/landscape-architecture.WebAPI/landscape-architecture.WebAPI/Services/IFilesService.cs
@@ -1,8 +1,10 @@
-﻿namespace landscape_architecture.WebAPI.Services
+﻿using landscape_architecture.WebAPI.DTO;
+
+namespace landscape_architecture.WebAPI.Services
 {
     public interface IFilesService
     {
-        Task<string> UploadFile(IFormFile formFile);
+        Task<string> UploadFile(FileUploadDTO formFile);
 
         Task<(byte[], string, string)?> DownloadFile(string fileName);
     }

--- a/landscape-architecture/src/components/FileUpload.vue
+++ b/landscape-architecture/src/components/FileUpload.vue
@@ -57,6 +57,7 @@ const onSubmit = async () => {
   }
 
   // Send the file to the API which takes a IFormFile as input
+  // TODO: change endpoint to environment variable and to deployed endpoint (when it is deployed)
   const response = await fetch('https://localhost:4000/api/v0/Files/UploadFile', {
     method: 'POST',
     body: formData,

--- a/landscape-architecture/src/components/FileUpload.vue
+++ b/landscape-architecture/src/components/FileUpload.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="pa-6">
     <div class="d-flex">
-      <v-file-input 
+      <v-file-input
         @change="onFileSelected"
         @click:clear="clearFile"
         clearable
@@ -18,12 +18,12 @@
       </v-btn>
     </div>
   </v-container>
-  
+
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-// Correct my typescript if I'm wrong
+
 const file = ref<File | null>(null)
 
 // Call this function when user selects a file
@@ -45,8 +45,20 @@ const onSubmit = async () => {
     return
   }
 
-  console.log('Uploading file data:', file.value)
-  // Add logic to send file to server
+  // Send the file to the API which takes a IFormFile as input
+  const formData = new FormData()
+  formData.append('file', file.value)
+
+
+  const response = await fetch('https://localhost:4000/api/v0/Files/UploadFile', {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    throw new Error('Upload failed');
+  }
+  console.log('Upload successful');
 }
 </script>
 

--- a/landscape-architecture/src/components/FileUpload.vue
+++ b/landscape-architecture/src/components/FileUpload.vue
@@ -5,6 +5,7 @@
         @change="onFileSelected"
         @click:clear="clearFile"
         clearable
+        variant="outlined"
         label="Upload 3D object"
         accept=".obj"
         hint="must be .obj file"
@@ -22,34 +23,40 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
 
-const file = ref<File | null>(null)
+const formData = new FormData();
 
 // Call this function when user selects a file
-const onFileSelected = (selectedFile: File) => {
-  console.log('File selected:', selectedFile)
-  file.value = selectedFile
+const onFileSelected = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  const file: File = (target.files as FileList)[0];
+
+  // Check if the file is an .obj file
+  if (file.name.split('.').pop() !== 'obj') {
+    return;
+  }
+
+  // Add the file to the FormData object
+  formData.append('formFile', file);
+  formData.append('fileName', file.name);
+
+  console.log('File selected ' + file.name);
 }
 
 // When the clear icon is clicked, clear the file
 const clearFile = () => {
-  file.value = null
+  formData.delete('formFile');
+  formData.delete('fileName');
 }
 
 // When the submit button is clicked, upload the file
-// TODO: Implement the API call to upload the file
 const onSubmit = async () => {
-  if (!file.value) {
-    console.log('No file selected.')
-    return
+  // Check if a file has been selected
+  if (!formData.has('formFile')) {
+    return;
   }
 
   // Send the file to the API which takes a IFormFile as input
-  const formData = new FormData()
-  formData.append('file', file.value)
-
-
   const response = await fetch('https://localhost:4000/api/v0/Files/UploadFile', {
     method: 'POST',
     body: formData,


### PR DESCRIPTION
This closes #47 

- File upload on frontend sends the file and its name as a FormData object
- Endpoint accepts a FileUploadDTO with the filename and IFormFile object
- File is added to database with a format similar to name_millisinceepoch.extension

Some notes,
- May eventually want to add more frontend validation to ensure file type and size is valid
- May want to store the endpoint on the frontend as a secret/environment variable